### PR TITLE
Fix incorrect user settings path

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -21,7 +21,7 @@
                             },
                             {
                                 "command": "open_file",
-                                "args": {"file": "${packages}/User/Rust Enhanced.sublime-settings"},
+                                "args": {"file": "${packages}/User/RustEnhanced.sublime-settings"},
                                 "caption": "Settings – User"
                             }
                         ]


### PR DESCRIPTION
The menu item to open the user settings file incorrectly includes a space, preventing any user settings from being loaded.